### PR TITLE
Make devpost link show on export-schedule-detailed

### DIFF
--- a/pages/api/export-schedule-detailed.ts
+++ b/pages/api/export-schedule-detailed.ts
@@ -38,7 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 		item.judges[1]?.name,
 		item.judges[2]?.name,
 		item.team.name,
-		item.devpost,
+		item.team.devpost,
 		item.team.members[0]?.name,
 		item.team.members[1]?.name,
 		item.team.members[2]?.name,


### PR DESCRIPTION
Devpost link now shows up properly on export-schedule-detailed