### PR TITLE
use url hostname

### DIFF
--- a/pages/api/team-management.ts
+++ b/pages/api/team-management.ts
@@ -75,7 +75,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 			if (devpost) {
 				try {
 					const _url = new URL(devpost);	
-					if (_url.hostname !== "devpost.com")) throw Error();
+					if (_url.hostname !== "devpost.com") throw Error();
 				} catch {
 					return res.status(404).send("Make sure your Devpost URL is formatted correctly — does it start with https://devpost.com?");
 				}


### PR DESCRIPTION
since we're already making it into a URL for validation, this fixes that codeql thingy https://github.com/VandyHacks/witness/security/code-scanning/1?query=ref%3Arefs%2Fpull%2F57%2Fmerge