### PR TITLE
Fix teams dropdown for organizers

### DIFF
--- a/components/teamSelect.tsx
+++ b/components/teamSelect.tsx
@@ -31,15 +31,15 @@ export default function TeamSelect(props: TeamSelectProps) {
 					{teamsData
 						.filter(team => team.isMine)
 						.map(team => (
-							<Option value={team.teamID} key={team.teamID}>
-								{team.haveJudged ? withCheckMark(team.teamName) : team.teamName}
+							<Option value={team.id} key={team.id}>
+								{team.haveJudged ? withCheckMark(team.name) : team.name}
 							</Option>
 						))}
 				</OptGroup>
 				<OptGroup label="All Teams">
 					{teamsData.map(team => (
-						<Option value={team.teamID} key={`${team.teamID}ALL`}>
-							{team.haveJudged ? withCheckMark(team.teamName) : team.teamName}
+						<Option value={team.id} key={`${team.id}ALL`}>
+							{team.haveJudged ? withCheckMark(team.name) : team.name}
 						</Option>
 					))}
 				</OptGroup>

--- a/pages/api/teams.ts
+++ b/pages/api/teams.ts
@@ -18,6 +18,7 @@ export interface Teams {
 
 export default async function handler(
 	req: NextApiRequest,
+	// TeamSelectData[] for judges, TeamData[] for organizers, string for error
 	res: NextApiResponse<TeamSelectData[] | Teams[] | string>
 ): Promise<void> {
 	const session = await getSession({ req });
@@ -54,8 +55,8 @@ export default async function handler(
 
 				const teamsData = teams.map(team => {
 					return {
-						teamID: team.id,
-						teamName: team.name,
+						id: team.id,
+						name: team.name,
 						isMine: scheduleMap.get(team.id.toString())?.includes(judgeID),
 						haveJudged: scoresMap.get(team.id.toString())?.includes(judgeID),
 					};

--- a/pages/judging.tsx
+++ b/pages/judging.tsx
@@ -78,6 +78,7 @@ export default function Forms() {
 			error.status = res.status;
 			throw error;
 		}
+		// Type is TeamSelectData[] for judges and TeamData[] for organizers
 		return (await res.json()) as TeamSelectData[] | TeamData[];
 	});
 

--- a/types/client.ts
+++ b/types/client.ts
@@ -29,8 +29,8 @@ export interface JudgingFormFields {
 }
 
 export interface TeamSelectData {
-	teamID: string;
-	teamName: string;
+	id: string;
+	name: string;
 	isMine: boolean;
 	haveJudged: boolean;
 }


### PR DESCRIPTION
Fixes N-W56

This issue arose because the name and id keys were different depending on if the user was an organizer or a judge. To fix this, I just made the names the same for both, matching what is provided by the database as well as comments indicating why the type can be different since it's not that obvious.