### PR TITLE
Fixed bug N-W23 with judging table

### DIFF
--- a/components/schedule.tsx
+++ b/components/schedule.tsx
@@ -287,7 +287,7 @@ export function JudgeSchedule({ data, cutoffIndex }: ScheduleProps) {
 			summary={_ => (
 				<Table.Summary fixed={true}>
 					<Table.Summary.Row>
-						<Table.Summary.Cell index={0} colSpan={5}>
+						<Table.Summary.Cell index={0} colSpan={6}>
 							<Switch
 								checkedChildren="Hide past sessions"
 								unCheckedChildren="Include past sessions"


### PR DESCRIPTION
[N-W23: Hide previous sessions bar doesn't go fully across the table](https://www.notion.so/vandyhacks/Witness-Bugs-c80db7b26ebf4b23bd811e64897f9d88#6bc100d4595d44079e996ff38d9b751d)