### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,13 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   ref: ${{ github.head_ref }}
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 16
             - name: Run Prettier
               run: yarn install --frozen-lockfile && yarn prettier --write .
             - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Prettier job currently fails due to node version. See e.g. https://github.com/VandyHacks/witness/actions/runs/4567918262/jobs/8062307683. Reported error:
> error next-auth@4.10.3: The engine "node" is incompatible with this module. Expected version "^12.19.0 || ^14.15.0 || ^16.13.0". Got "18.15.0"


Updated workflow to use Node 16