### PR TITLE
change from noreply to updates

### DIFF
--- a/email/templates/accepted.ts
+++ b/email/templates/accepted.ts
@@ -42,5 +42,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: "You've Been Accepted!",
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });

--- a/email/templates/confirmed.ts
+++ b/email/templates/confirmed.ts
@@ -47,5 +47,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: 'See you soon!',
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });

--- a/email/templates/rejected.ts
+++ b/email/templates/rejected.ts
@@ -37,5 +37,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: 'Thank you for applying to VandyHacks',
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });

--- a/email/templates/reminderToSubmit.ts
+++ b/email/templates/reminderToSubmit.ts
@@ -39,5 +39,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: 'Applications Closing Soon!',
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });

--- a/email/templates/submitted.ts
+++ b/email/templates/submitted.ts
@@ -39,5 +39,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: "We've Received Your Application!",
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });

--- a/email/templates/travelForm.ts
+++ b/email/templates/travelForm.ts
@@ -39,5 +39,5 @@ export default async (user: UserData): Promise<SendEmailRequest> => ({
 			Data: 'Apply for a Travel Reimbursement to VandyHacks X!',
 		},
 	},
-	Source: 'VandyHacks <noreply@vandyhacks.org>',
+	Source: 'VandyHacks <updates@vandyhacks.org>',
 });


### PR DESCRIPTION
## What? 
Previously our emails are sent from `noreply@vandyhacks.org`. 
Created a new email in AWS SES and configured Cloudflare to make that happen.
Now our emails should come from `updates@vandyhacks.org` 

## Will it go to spam again? 
Testing it with Vanderbilt email. It should work. 
Merge this PR after we get confirmation on our dev slack channel