### PR TITLE
replace __dirname with process.cwd()

### DIFF
--- a/email/utils.ts
+++ b/email/utils.ts
@@ -10,8 +10,8 @@ import { ApplicationStatus, UserData } from '../types/database';
  */
 const getHtmlTemplate = (template: string) => {
 	// assume directory is currently in /pages/api/, need to go to /email/html/...
-	// console.log('directory: ', path.join(__dirname, `../../email/html/${template}.html`));
-	return readFile(path.join(__dirname, `../../email/html/${template}.html`), 'utf8');
+	// console.log('directory: ', path.join(process.cwd(), `/email/html/${template}.html`));
+	return readFile(path.join(process.cwd(), `/email/html/${template}.html`), 'utf8');
 };
 
 /**

--- a/next.config.js
+++ b/next.config.js
@@ -14,4 +14,5 @@ module.exports = {
 
 		return config;
 	},
+	experimental: { nftTracing: true },
 };


### PR DESCRIPTION
## Deployment issue

The behavior of `__dirname` behaves differently on production. It is recommended to use `process.cwd()` instead. [Source](https://github.com/vercel/next.js/issues/8251\#issuecomment-915287535)

<img width="934" alt="image" src="https://github.com/VandyHacks/witness/assets/58854510/f1bb33a2-387e-4dfb-a4c6-a3a2ff5e4957">
