### PR TITLE
Refactor judging scheduling from organizer view

### DIFF
--- a/components/Organizer/ScheduleTab/ScheduleTab.tsx
+++ b/components/Organizer/ScheduleTab/ScheduleTab.tsx
@@ -108,32 +108,25 @@ const ScheduleTab = () => {
 				<div>Loading...</div>
 			) : (
 				<>
-                    <Row style={{marginBottom: "-8px"}}>
-                        <Col style={{margin: "auto 8px auto 0"}}>
-                            Number of Judging Sessions Per Team:
-                        </Col>
-                        <Col>
-                            <InputNumber
-                                style={{ margin: '0 1px' }}
-                                min={1}
-                                max={10}
-                                value={timesJudged || null}
-                                onChange={input => {
-                                    setTimesJudged(input || 1);
-                                }}
-                                status={1 <= timesJudged && timesJudged <= maxTimesJudged ? '' : 'error'}
-                            />
-                        </Col>
-                        <Col span={4}>
-                            <Slider
-                                min={1}
-                                max={10}
-                                onChange={setTimesJudged}
-                                value={timesJudged}
-                            />
-                        </Col>
-                    </Row>
-                    <br />
+					<Row style={{ marginBottom: '-8px' }}>
+						<Col style={{ margin: 'auto 8px auto 0' }}>Number of Judging Sessions Per Team:</Col>
+						<Col>
+							<InputNumber
+								style={{ margin: '0 1px' }}
+								min={1}
+								max={10}
+								value={timesJudged || null}
+								onChange={input => {
+									setTimesJudged(input || 1);
+								}}
+								status={1 <= timesJudged && timesJudged <= maxTimesJudged ? '' : 'error'}
+							/>
+						</Col>
+						<Col span={4}>
+							<Slider min={1} max={10} onChange={setTimesJudged} value={timesJudged} />
+						</Col>
+					</Row>
+					<br />
 					<Button
 						onClick={() => handleCreateNewPotentialSchedules(teamsData, judgesData)}
 						style={{ marginBottom: '10px' }}>

--- a/components/Organizer/ScheduleTab/ScheduleTab.tsx
+++ b/components/Organizer/ScheduleTab/ScheduleTab.tsx
@@ -1,21 +1,21 @@
-import { Button, Skeleton, Divider } from 'antd';
+import { Button, InputNumber } from 'antd';
 import { SetStateAction, useContext, useEffect, useState } from 'react';
 import {
-	TIMES_JUDGED,
-	generateScheduleA,
-	generateScheduleB,
+	matchTeams,
 	handleConfirmSchedule,
 } from '../../../utils/organizer-utils';
-import OrganizerSchedule from '../../judges/schedule';
-import { ResponseError, JudgingSessionData, UserData, TeamData } from '../../../types/database';
+import OrganizerSchedule, { generateTimes } from '../../judges/schedule';
+import { ResponseError, JudgingSessionData, UserData, TeamData, HackathonSettingsData } from '../../../types/database';
 import Title from 'antd/lib/typography/Title';
 import { RequestType, useCustomSWR } from '../../../utils/request-utils';
 import { ThemeContext, getBaseColor } from '../../../theme/themeProvider';
+import { handleSubmitFailure } from '../../../lib/helpers';
 
 const ScheduleTab = () => {
 	// React state
-	const [potentialScheduleA, setPotentialScheduleA] = useState<JudgingSessionData[] | undefined>(undefined);
-	const [potentialScheduleB, setPotentialScheduleB] = useState<JudgingSessionData[] | undefined>(undefined);
+    const [timesJudged, setTimesJudged] = useState<number>(0);
+    const [maxTimesJudged, setMaxTimesJudged] = useState<number>(0);
+	const [potentialSchedule, setPotentialSchedule] = useState<JudgingSessionData[] | undefined>(undefined);
 
 	const { baseTheme } = useContext(ThemeContext);
 
@@ -28,33 +28,34 @@ const ScheduleTab = () => {
 
 	// Judge data
 	const { data: judgesData, error: judgesError } = useCustomSWR<UserData[]>({
-		url: '/api/users?usertype=JUDGE',
+		url: '/api/users?usertype=JUDGE&isCheckedIn=true',
 		method: RequestType.GET,
 		errorMessage: 'Failed to get list of judges.',
 	});
 
 	// Teams data
 	const { data: teamsData, error: teamsError } = useCustomSWR<TeamData[]>({
-		url: '/api/teams',
+		url: '/api/teams?submitted=true',
 		method: RequestType.GET,
 		errorMessage: 'Failed to get list of teams.',
 	});
 
-	// Check if schedule is impossible
-	const isScheduleImpossible = () =>
-		teamsData && judgesData && (teamsData.length * TIMES_JUDGED) / 12 > judgesData.length;
+    // Get hackathon settings
+    const { data: hackathonSettings, error: hackathonError } = useCustomSWR<HackathonSettingsData>({
+        url: '/api/hackathon-settings',
+        method: RequestType.GET,
+        errorMessage: 'Failed to get hackathon times.',
+    });
 
 	// Confirm potential schedule
 	const handleConfirmPotentialSchedules = (
-		potentialScheduleA: JudgingSessionData[] | undefined,
-		potentialScheduleB: JudgingSessionData[] | undefined
+		potentialSchedule: JudgingSessionData[] | undefined,
 	) => {
 		// Exit early if we don't have data yet
-		if (!potentialScheduleA || !potentialScheduleB) return;
+		if (!potentialSchedule) return;
 
 		// Send requests to confirm the schedule
-		handleConfirmSchedule(potentialScheduleA);
-		handleConfirmSchedule(potentialScheduleB);
+		handleConfirmSchedule(potentialSchedule);
 	};
 
 	// Set potential schedule
@@ -62,10 +63,20 @@ const ScheduleTab = () => {
 		// Confirm with user
 		if (!window.confirm('Are you sure you want to create a new schedule?')) return;
 
+        if (timesJudged < 1 || timesJudged > maxTimesJudged) {
+            handleSubmitFailure("Invalid number of judging sessions per team.");
+            return;
+        }
+        
 		// Set that potential schedules as newly generated schedules
-		setPotentialScheduleA(generateScheduleA(teams, judges));
-		setPotentialScheduleB(generateScheduleB(teams, judges));
+        let judgingTimes = generateTimes(new Date(hackathonSettings?.JUDGING_START as string), new Date(hackathonSettings?.JUDGING_END as string), 10);
+        setPotentialSchedule(matchTeams(teams, judges, judgingTimes, timesJudged));
 	};
+
+    useEffect(() => {
+        if (!teamsData || !judgesData) return;
+        setMaxTimesJudged(Math.floor(judgesData?.length * 12 / teamsData?.length));
+    }, [teamsData, judgesData])
 
 	useEffect(() => {
 		// Exit early if we don't have data yet
@@ -75,11 +86,11 @@ const ScheduleTab = () => {
 		const time = new Date('2022-10-23T11:00:00').getTime();
 
 		// Set the data after filtering it by time
-		setPotentialScheduleA(
-			judgingSessions.filter(judgingSession => new Date(judgingSession.time as string).getTime() < time)
-		);
-		setPotentialScheduleB(
-			judgingSessions.filter(judgingSession => new Date(judgingSession.time as string).getTime() >= time)
+		setPotentialSchedule(
+			judgingSessions.filter(judgingSession => {
+                let time = new Date(judgingSession.time as string);
+                return new Date(hackathonSettings?.JUDGING_START as string) <= time && time <= new Date(hackathonSettings?.JUDGING_END as string);
+            })
 		);
 	}, [judgingSessions]);
 
@@ -95,58 +106,38 @@ const ScheduleTab = () => {
 				<div>Loading...</div>
 			) : (
 				<>
+                    <InputNumber placeholder="Number judging sessions per team" style={{ width: 250 }} value={timesJudged || null} onChange={(input) => {setTimesJudged(input || 0);}} status={1 <= timesJudged && timesJudged <= maxTimesJudged ? "" : "error"}/>
 					<Button
 						onClick={() => handleCreateNewPotentialSchedules(teamsData, judgesData)}
 						style={{ marginBottom: '10px' }}>
 						Generate Potential Judging Schedule
 					</Button>
-					{potentialScheduleA && potentialScheduleB && (
+					{potentialSchedule && (
 						<Button
-							onClick={() => handleConfirmPotentialSchedules(potentialScheduleA, potentialScheduleB)}
+							onClick={() => handleConfirmPotentialSchedules(potentialSchedule)}
 							style={{ marginBottom: '10px' }}>
 							Confirm Schedule
 						</Button>
 					)}
 
 					<br />
-					{isScheduleImpossible() ? (
-						<div>The schedule is impossible! Run.</div>
-					) : (
-						<div>The schedule is possible!</div>
-					)}
 					<div>Count of Teams: {teamsData?.length}</div>
 					<div>Count of Judges: {judgesData?.length}</div>
+                    <div>Maximum Possible Number of Judging Sessions Per Team: {maxTimesJudged}</div>
 					<Title
 						style={{
 							color: getBaseColor(baseTheme),
 						}}>
-						Expo A
+						Judging Schedule
 					</Title>
-					{potentialScheduleA && (
+					{potentialSchedule && (
 						<OrganizerSchedule
-							data={potentialScheduleA}
+							data={potentialSchedule}
 							handleChange={function (value: SetStateAction<string>): void {
 								throw new Error('Function not implemented.');
 							}}
-							sessionTimeStart={new Date('2022-10-23T10:00:00')}
-							sessionTimeEnd={new Date('2022-10-23T11:00:00')}
-						/>
-					)}
-					<div style={{ height: '20px' }} />
-					<Title
-						style={{
-							color: getBaseColor(baseTheme),
-						}}>
-						Expo B
-					</Title>
-					{potentialScheduleB && (
-						<OrganizerSchedule
-							data={potentialScheduleB}
-							handleChange={function (value: SetStateAction<string>): void {
-								throw new Error('Function not implemented.');
-							}}
-							sessionTimeStart={new Date('2022-10-23T11:30:00')}
-							sessionTimeEnd={new Date('2022-10-23T12:30:00')}
+							sessionTimeStart={new Date(hackathonSettings?.JUDGING_START as string)}
+							sessionTimeEnd={new Date(hackathonSettings?.JUDGING_END as string)}
 						/>
 					)}
 				</>

--- a/components/Organizer/ScheduleTab/ScheduleTab.tsx
+++ b/components/Organizer/ScheduleTab/ScheduleTab.tsx
@@ -1,4 +1,4 @@
-import { Button, InputNumber } from 'antd';
+import { Button, InputNumber, Slider, Row, Col } from 'antd';
 import { SetStateAction, useContext, useEffect, useState } from 'react';
 import { matchTeams, handleConfirmSchedule } from '../../../utils/organizer-utils';
 import OrganizerSchedule, { generateTimes } from '../../judges/schedule';
@@ -10,7 +10,7 @@ import { handleSubmitFailure } from '../../../lib/helpers';
 
 const ScheduleTab = () => {
 	// React state
-	const [timesJudged, setTimesJudged] = useState<number>(0);
+	const [timesJudged, setTimesJudged] = useState<number>(1);
 	const [maxTimesJudged, setMaxTimesJudged] = useState<number>(0);
 	const [potentialSchedule, setPotentialSchedule] = useState<JudgingSessionData[] | undefined>(undefined);
 
@@ -108,15 +108,32 @@ const ScheduleTab = () => {
 				<div>Loading...</div>
 			) : (
 				<>
-					<InputNumber
-						placeholder="Number judging sessions per team"
-						style={{ width: 250 }}
-						value={timesJudged || null}
-						onChange={input => {
-							setTimesJudged(input || 0);
-						}}
-						status={1 <= timesJudged && timesJudged <= maxTimesJudged ? '' : 'error'}
-					/>
+                    <Row style={{marginBottom: "-8px"}}>
+                        <Col style={{margin: "auto 8px auto 0"}}>
+                            Number of Judging Sessions Per Team:
+                        </Col>
+                        <Col>
+                            <InputNumber
+                                style={{ margin: '0 1px' }}
+                                min={1}
+                                max={10}
+                                value={timesJudged || null}
+                                onChange={input => {
+                                    setTimesJudged(input || 1);
+                                }}
+                                status={1 <= timesJudged && timesJudged <= maxTimesJudged ? '' : 'error'}
+                            />
+                        </Col>
+                        <Col span={4}>
+                            <Slider
+                                min={1}
+                                max={10}
+                                onChange={setTimesJudged}
+                                value={timesJudged}
+                            />
+                        </Col>
+                    </Row>
+                    <br />
 					<Button
 						onClick={() => handleCreateNewPotentialSchedules(teamsData, judgesData)}
 						style={{ marginBottom: '10px' }}>

--- a/components/Organizer/ScheduleTab/ScheduleTab.tsx
+++ b/components/Organizer/ScheduleTab/ScheduleTab.tsx
@@ -94,7 +94,7 @@ const ScheduleTab = () => {
 				);
 			})
 		);
-	}, [judgingSessions]);
+	}, [judgingSessions, hackathonSettings]);
 
 	// Combine all the loading, null, and error states
 	const error = judgingSessionsError || judgesError || teamsError;

--- a/components/Organizer/ScheduleTab/ScheduleTab.tsx
+++ b/components/Organizer/ScheduleTab/ScheduleTab.tsx
@@ -1,9 +1,6 @@
 import { Button, InputNumber } from 'antd';
 import { SetStateAction, useContext, useEffect, useState } from 'react';
-import {
-	matchTeams,
-	handleConfirmSchedule,
-} from '../../../utils/organizer-utils';
+import { matchTeams, handleConfirmSchedule } from '../../../utils/organizer-utils';
 import OrganizerSchedule, { generateTimes } from '../../judges/schedule';
 import { ResponseError, JudgingSessionData, UserData, TeamData, HackathonSettingsData } from '../../../types/database';
 import Title from 'antd/lib/typography/Title';
@@ -13,8 +10,8 @@ import { handleSubmitFailure } from '../../../lib/helpers';
 
 const ScheduleTab = () => {
 	// React state
-    const [timesJudged, setTimesJudged] = useState<number>(0);
-    const [maxTimesJudged, setMaxTimesJudged] = useState<number>(0);
+	const [timesJudged, setTimesJudged] = useState<number>(0);
+	const [maxTimesJudged, setMaxTimesJudged] = useState<number>(0);
 	const [potentialSchedule, setPotentialSchedule] = useState<JudgingSessionData[] | undefined>(undefined);
 
 	const { baseTheme } = useContext(ThemeContext);
@@ -40,17 +37,15 @@ const ScheduleTab = () => {
 		errorMessage: 'Failed to get list of teams.',
 	});
 
-    // Get hackathon settings
-    const { data: hackathonSettings, error: hackathonError } = useCustomSWR<HackathonSettingsData>({
-        url: '/api/hackathon-settings',
-        method: RequestType.GET,
-        errorMessage: 'Failed to get hackathon times.',
-    });
+	// Get hackathon settings
+	const { data: hackathonSettings, error: hackathonError } = useCustomSWR<HackathonSettingsData>({
+		url: '/api/hackathon-settings',
+		method: RequestType.GET,
+		errorMessage: 'Failed to get hackathon times.',
+	});
 
 	// Confirm potential schedule
-	const handleConfirmPotentialSchedules = (
-		potentialSchedule: JudgingSessionData[] | undefined,
-	) => {
+	const handleConfirmPotentialSchedules = (potentialSchedule: JudgingSessionData[] | undefined) => {
 		// Exit early if we don't have data yet
 		if (!potentialSchedule) return;
 
@@ -63,20 +58,24 @@ const ScheduleTab = () => {
 		// Confirm with user
 		if (!window.confirm('Are you sure you want to create a new schedule?')) return;
 
-        if (timesJudged < 1 || timesJudged > maxTimesJudged) {
-            handleSubmitFailure("Invalid number of judging sessions per team.");
-            return;
-        }
-        
+		if (timesJudged < 1 || timesJudged > maxTimesJudged) {
+			handleSubmitFailure('Invalid number of judging sessions per team.');
+			return;
+		}
+
 		// Set that potential schedules as newly generated schedules
-        let judgingTimes = generateTimes(new Date(hackathonSettings?.JUDGING_START as string), new Date(hackathonSettings?.JUDGING_END as string), 10);
-        setPotentialSchedule(matchTeams(teams, judges, judgingTimes, timesJudged));
+		let judgingTimes = generateTimes(
+			new Date(hackathonSettings?.JUDGING_START as string),
+			new Date(hackathonSettings?.JUDGING_END as string),
+			10
+		);
+		setPotentialSchedule(matchTeams(teams, judges, judgingTimes, timesJudged));
 	};
 
-    useEffect(() => {
-        if (!teamsData || !judgesData) return;
-        setMaxTimesJudged(Math.floor(judgesData?.length * 12 / teamsData?.length));
-    }, [teamsData, judgesData])
+	useEffect(() => {
+		if (!teamsData || !judgesData) return;
+		setMaxTimesJudged(Math.floor((judgesData?.length * 12) / teamsData?.length));
+	}, [teamsData, judgesData]);
 
 	useEffect(() => {
 		// Exit early if we don't have data yet
@@ -88,9 +87,12 @@ const ScheduleTab = () => {
 		// Set the data after filtering it by time
 		setPotentialSchedule(
 			judgingSessions.filter(judgingSession => {
-                let time = new Date(judgingSession.time as string);
-                return new Date(hackathonSettings?.JUDGING_START as string) <= time && time <= new Date(hackathonSettings?.JUDGING_END as string);
-            })
+				let time = new Date(judgingSession.time as string);
+				return (
+					new Date(hackathonSettings?.JUDGING_START as string) <= time &&
+					time <= new Date(hackathonSettings?.JUDGING_END as string)
+				);
+			})
 		);
 	}, [judgingSessions]);
 
@@ -106,7 +108,15 @@ const ScheduleTab = () => {
 				<div>Loading...</div>
 			) : (
 				<>
-                    <InputNumber placeholder="Number judging sessions per team" style={{ width: 250 }} value={timesJudged || null} onChange={(input) => {setTimesJudged(input || 0);}} status={1 <= timesJudged && timesJudged <= maxTimesJudged ? "" : "error"}/>
+					<InputNumber
+						placeholder="Number judging sessions per team"
+						style={{ width: 250 }}
+						value={timesJudged || null}
+						onChange={input => {
+							setTimesJudged(input || 0);
+						}}
+						status={1 <= timesJudged && timesJudged <= maxTimesJudged ? '' : 'error'}
+					/>
 					<Button
 						onClick={() => handleCreateNewPotentialSchedules(teamsData, judgesData)}
 						style={{ marginBottom: '10px' }}>
@@ -123,7 +133,7 @@ const ScheduleTab = () => {
 					<br />
 					<div>Count of Teams: {teamsData?.length}</div>
 					<div>Count of Judges: {judgesData?.length}</div>
-                    <div>Maximum Possible Number of Judging Sessions Per Team: {maxTimesJudged}</div>
+					<div>Maximum Possible Number of Judging Sessions Per Team: {maxTimesJudged}</div>
 					<Title
 						style={{
 							color: getBaseColor(baseTheme),

--- a/components/judges/schedule.tsx
+++ b/components/judges/schedule.tsx
@@ -91,8 +91,9 @@ export default function OrganizerSchedule(props: ScheduleProps) {
 					dataIndex: teamName as string,
 					key: teamName as string,
 					render: TableCell,
+                    locationNum: locationNum,
 				};
-			}),
+			}).sort((a, b) => (a.locationNum as number) - (b.locationNum as number)),
 		],
 		[teams, data]
 	);

--- a/components/judges/schedule.tsx
+++ b/components/judges/schedule.tsx
@@ -82,18 +82,20 @@ export default function OrganizerSchedule(props: ScheduleProps) {
 				width: 100,
 				render: (time: string) => DateTime.fromISO(time).toLocaleString(DateTime.TIME_SIMPLE),
 			},
-			...teams.map(teamName => {
-				let locationNum = data
-					.filter(x => x.team !== null && x.team.name !== null)
-					.find(x => x.team.name === teamName)?.team.locationNum;
-				return {
-					title: (teamName as string) + ' (Table ' + locationNum + ')',
-					dataIndex: teamName as string,
-					key: teamName as string,
-					render: TableCell,
-                    locationNum: locationNum,
-				};
-			}).sort((a, b) => (a.locationNum as number) - (b.locationNum as number)),
+			...teams
+				.map(teamName => {
+					let locationNum = data
+						.filter(x => x.team !== null && x.team.name !== null)
+						.find(x => x.team.name === teamName)?.team.locationNum;
+					return {
+						title: (teamName as string) + ' (Table ' + locationNum + ')',
+						dataIndex: teamName as string,
+						key: teamName as string,
+						render: TableCell,
+						locationNum: locationNum,
+					};
+				})
+				.sort((a, b) => (a.locationNum as number) - (b.locationNum as number)),
 		],
 		[teams, data]
 	);

--- a/pages/api/teams.ts
+++ b/pages/api/teams.ts
@@ -25,9 +25,9 @@ export default async function handler(
 	if (req.method === 'GET') {
 		let teams = await Team.find();
 
-        if (req.query.submitted) {
-            teams = teams.filter(team => team.devpost !== '');
-        }
+		if (req.query.submitted) {
+			teams = teams.filter(team => team.devpost !== '');
+		}
 
 		switch (session!.userType) {
 			// send all team info to organizer

--- a/pages/api/teams.ts
+++ b/pages/api/teams.ts
@@ -23,7 +23,12 @@ export default async function handler(
 	if (!['JUDGE', 'ORGANIZER'].includes(session?.userType as string)) return res.status(403).send('Forbidden');
 
 	if (req.method === 'GET') {
-		const teams = await Team.find();
+		let teams = await Team.find();
+
+        if (req.query.submitted) {
+            teams = teams.filter(team => team.devpost !== '');
+        }
+
 		switch (session!.userType) {
 			// send all team info to organizer
 			case 'ORGANIZER': {

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -22,6 +22,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				users = users.populate('application');
 			}
 
+            if (userType == 'JUDGE' && req.query.isCheckedIn){
+                users = users.where('isJudgeCheckedIn').equals(true);
+            }
+
 			return res.status(200).send(await users);
 		default:
 			return res.status(405).send('Method not supported brother');

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -22,9 +22,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				users = users.populate('application');
 			}
 
-            if (userType == 'JUDGE' && req.query.isCheckedIn){
-                users = users.where('isJudgeCheckedIn').equals(true);
-            }
+			if (userType == 'JUDGE' && req.query.isCheckedIn) {
+				users = users.where('isJudgeCheckedIn').equals(true);
+			}
 
 			return res.status(200).send(await users);
 		default:

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -22,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				users = users.populate('application');
 			}
 
-			if (userType == 'JUDGE' && req.query.isCheckedIn) {
+			if (userType === 'JUDGE' && req.query.isCheckedIn) {
 				users = users.where('isJudgeCheckedIn').equals(true);
 			}
 

--- a/utils/organizer-utils.ts
+++ b/utils/organizer-utils.ts
@@ -1,46 +1,6 @@
 import { ScopedMutator } from 'swr/dist/types';
-import { ManageFormFields } from '../components/Organizer/ManageUsersTab/manageRoleForm';
-import { generateTimes } from '../components/judges/schedule';
 import { handleSubmitSuccess, handleSubmitFailure } from '../lib/helpers';
 import { JudgingSessionData, PreAddData, TeamData, UserData } from '../types/database';
-
-/**
- * The number of times each team will be judged.
- * @type {number}
- */
-export const TIMES_JUDGED = 3;
-
-/**
- * Generates schedule sessions for Teams A based on the given array of teams and judges.
- * @param {TeamData[]} teams - The array of team data objects to generate sessions for.
- * @param {UserData[]} judges - The array of user data objects from which judges will be selected.
- * @returns {Array} An array of schedule session data objects for Teams A.
- */
-export const generateScheduleA = (teams: TeamData[], judges: UserData[]) => {
-	const teamsPerSession = Math.floor(teams.length / 2);
-
-	const timesOne = generateTimes(new Date('2022-10-23T10:00:00'), new Date('2022-10-23T11:00:00'), 10);
-
-	const sessionsA = matchTeams(teams.slice(0, teamsPerSession), judges, timesOne);
-
-	return sessionsA;
-};
-
-/**
- * Generates schedule sessions for Teams B based on the given array of teams and judges.
- * @param {TeamData[]} teams - The array of team data objects to generate sessions for.
- * @param {UserData[]} judges - The array of user data objects from which judges will be selected.
- * @returns {Array} An array of schedule session data objects for Teams B.
- */
-export const generateScheduleB = (teams: TeamData[], judges: UserData[]) => {
-	const teamsPerSession = Math.floor(teams.length / 2);
-
-	const timesTwo = generateTimes(new Date('2022-10-23T11:30:00'), new Date('2022-10-23T12:30:00'), 10);
-
-	const sessionsB = matchTeams(teams.slice(teamsPerSession, teams.length), judges, timesTwo);
-
-	return sessionsB;
-};
 
 /**
  * Handles pre-add user deletion with the specified user data.
@@ -73,10 +33,10 @@ export const handlePreAddDelete = async (user: PreAddData, mutate: ScopedMutator
  * @param {Date[]} times - The array of time slots for which to generate sessions.
  * @returns {Array} An array of schedule session data objects.
  */
-export const matchTeams = (teams: TeamData[], judges: UserData[], times: Date[]) => {
+export const matchTeams = (teams: TeamData[], judges: UserData[], times: Date[], timesJudged: number) => {
 	let sessions = [];
 
-	const numSessions = TIMES_JUDGED * teams.length;
+	const numSessions = timesJudged * teams.length;
 
 	const perTimes = Math.floor(numSessions / times.length);
 	let remTimes = numSessions % times.length;


### PR DESCRIPTION
Several changes to organizer view in terms of scheduling

1. Schedules are now generated using _checked in_ judges and _submitted_ teams (i.e. teams with a devpost).
2. Adjusted schedule for only one continuous session (no more expo a and expo b like last year). Judging start and end time are now pulled from the settings.
3. Allow organizers to adjust parameter for how many times each team is judged before generating schedule.
4. Sort teams in schedule according to table number for readability.

## Specifying 1 judging session per team
<img width="600" alt="image" src="https://github.com/VandyHacks/witness/assets/58854510/ebbe6ab2-4bdb-4f58-ac1c-930f9aaf85f1">

## Specifying 3 judging sessions per team
<img width="600" alt="image" src="https://github.com/VandyHacks/witness/assets/58854510/81f6a0b0-f569-4c29-a208-383043183726">

## Specifying invalid judging sessions per team
<img width="600" alt="image" src="https://github.com/VandyHacks/witness/assets/58854510/fad99b9f-89ec-4f1d-9697-c9f6d2ee93a4">
