### PR TITLE
Added search by login name to Organizer's manage applications tab

### DIFF
--- a/components/Organizer/ApplicantsTab/ApplicantsTab.tsx
+++ b/components/Organizer/ApplicantsTab/ApplicantsTab.tsx
@@ -258,6 +258,7 @@ export const ApplicantsTab = () => {
 		{
 			title: 'Login Name',
 			dataIndex: 'name',
+			...getColumnSearchProps('name'),
 		},
 		{
 			title: 'First Name',


### PR DESCRIPTION
Closes #452 

# What I've Done
- Added search by login name functionality to the Organizer Dashboard's "Manage Applications" tab

# What It Looks Like
![image](https://github.com/VandyHacks/witness/assets/89999830/55ec8e7e-e09c-4211-9b7f-21253d76caec)
